### PR TITLE
feat(worker): add redis queue for async move persistence (#20)

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "worker",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "tsx watch src/index.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "redis": "^5.11.0",
+    "@prisma/client": "6.3.1",
+    "@repo/db": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.10",
+    "esbuild": "^0.27.2",
+    "prisma": "6.3.1",
+    "ts-node": "^10.9.2",
+    "tsx": "^4.7.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apps/worker/src/db/index.ts
+++ b/apps/worker/src/db/index.ts
@@ -1,0 +1,6 @@
+// @ts-ignore
+import { PrismaClient } from '@repo/db';
+
+const client = new PrismaClient();
+
+export const db = client;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,0 +1,30 @@
+import {createClient} from "redis";
+import {db} from "./db";
+
+const redis = createClient();
+
+async function main(){
+    try{
+        await redis.connect();
+        while (1){
+            const response = await redis.brPop("moves",0);
+            if (response?.element){
+                const data = JSON.parse(response?.element)
+                await db.move.create({
+                    data: {
+                        gameId: data.gameId,
+                        playerId: data.playerId,
+                        from: data.from,
+                        to: data.to,
+                        moveNo: data.moveNo
+                    }
+                });
+            }
+            console.log("response not available")
+        }
+    }catch (err){
+        console.log("Failed to connect to the redis : ",err);
+    }
+}
+
+main();

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/apps/ws/package.json
+++ b/apps/ws/package.json
@@ -21,6 +21,7 @@
     "cookie": "^1.1.1",
     "jsonwebtoken": "^9.0.3",
     "next-auth": "^4.24.13",
+    "redis": "^5.11.0",
     "ws": "^8.19.0"
   },
   "devDependencies": {

--- a/apps/ws/src/game.ts
+++ b/apps/ws/src/game.ts
@@ -2,6 +2,8 @@ import {WebSocket} from "ws";
 import {Chess} from "chess.js";
 import {GAME_OVER, INIT_GAME, MOVES} from "./messages";
 import {db} from "./db";
+import {createClient} from "redis";
+
 
 interface player {
     playerId : string;
@@ -56,6 +58,7 @@ export class Game {
                 }
             }))
         }
+
     }
 
 
@@ -93,7 +96,7 @@ export class Game {
     public async makeMove(socket: WebSocket, move : {
         from : string,
         to : string
-    }, userId: string) {
+    }, userId: string , redis : any) {
         // validate turn
         if (this.moveCount % 2 === 0 && socket !== this.player1.Websocket) return;
         if (this.moveCount % 2 === 1 && socket !== this.player2.Websocket) return;
@@ -112,15 +115,13 @@ export class Game {
             payload: move
         }));
 
-        await db.move.create({
-            data: {
-                gameId: this.GAME_ID,
-                playerId: userId,
-                from: move.from,
-                to: move.to,
-                moveNo: this.moveCount - 1
-            }
-        });
+        await redis.lPush("moves",JSON.stringify({
+            gameId: this.GAME_ID,
+            playerId: userId,
+            from: move.from,
+            to: move.to,
+            moveNo: this.moveCount - 1
+        }))
     }
 
 

--- a/apps/ws/src/gameManger.ts
+++ b/apps/ws/src/gameManger.ts
@@ -2,10 +2,18 @@ import { WebSocket } from "ws";
 import { INIT_GAME, MOVES } from "./messages";
 import { Game } from "./game";
 import { db } from "./db";
+import {createClient, RedisClientType} from "redis";
 
 export class GameManager {
     private games: Game[] = [];
     private pendingUser: { socket: WebSocket; userId: string } | null = null;
+    private redis : any;
+
+    async redisConnect(){
+        this.redis = createClient();
+        await this.redis.connect();
+    }
+
 
     // Concurrency Avoiding Protocol: CAP
     private creatingGame: Set<string> = new Set();
@@ -48,7 +56,7 @@ export class GameManager {
             if (message.type === MOVES) {
                 const game = this.games.find((g) => g.player1.Websocket === socket || g.player2.Websocket === socket);
                 if (game) {
-                    game.makeMove(socket, message.payload.move, userId);
+                    game.makeMove(socket, message.payload.move, userId ,this.redis);
                 }
             }
 

--- a/apps/ws/src/index.ts
+++ b/apps/ws/src/index.ts
@@ -22,6 +22,7 @@ declare module "next-auth" {
 const server = http.createServer();
 const wss = new WebSocketServer({ noServer: true });
 const gameManager = new GameManager();
+gameManager.redisConnect();
 
 function getSessionToken(req: any) {
     console.log("fetcing the cookie")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,37 @@ importers:
         specifier: ^5
         version: 5.9.2
 
+  apps/worker:
+    dependencies:
+      '@prisma/client':
+        specifier: 6.3.1
+        version: 6.3.1(prisma@6.3.1(typescript@5.9.3))(typescript@5.9.3)
+      '@repo/db':
+        specifier: workspace:*
+        version: link:../../packages/db
+      redis:
+        specifier: ^5.11.0
+        version: 5.11.0
+    devDependencies:
+      '@types/node':
+        specifier: ^25.0.10
+        version: 25.0.10
+      esbuild:
+        specifier: ^0.27.2
+        version: 0.27.2
+      prisma:
+        specifier: 6.3.1
+        version: 6.3.1(typescript@5.9.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@25.0.10)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.7.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   apps/ws:
     dependencies:
       '@prisma/client':
@@ -296,6 +327,9 @@ importers:
       next-auth:
         specifier: ^4.24.13
         version: 4.24.13(next@16.1.1(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      redis:
+        specifier: ^5.11.0
+        version: 5.11.0
       ws:
         specifier: ^8.19.0
         version: 8.19.0
@@ -1652,6 +1686,39 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@redis/bloom@5.11.0':
+    resolution: {integrity: sha512-KYiVilAhAFN3057afUb/tfYJpsEyTkQB+tQcn5gVVA7DgcNOAj8lLxe4j8ov8BF6I9C1Fe/kwlbuAICcTMX8Lw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@redis/client': ^5.11.0
+
+  '@redis/client@5.11.0':
+    resolution: {integrity: sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+
+  '@redis/json@5.11.0':
+    resolution: {integrity: sha512-1iAy9kAtcD0quB21RbPTbUqqy+T2Uu2JxucwE+B4A+VaDbIRvpZR6DMqV8Iqaws2YxJYB3GC5JVNzPYio2ErUg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@redis/client': ^5.11.0
+
+  '@redis/search@5.11.0':
+    resolution: {integrity: sha512-g1l7f3Rnyk/xI99oGHIgWHSKFl45Re5YTIcO8j/JE8olz389yUFyz2+A6nqVy/Zi031VgPDWscbbgOk8hlhZ3g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@redis/client': ^5.11.0
+
+  '@redis/time-series@5.11.0':
+    resolution: {integrity: sha512-TWFeOcU4xkj0DkndnOyhtxvX1KWD+78UHT3XX3x3XRBUGWeQrKo3jqzDsZwxbggUgf9yLJr/akFHXru66X5UQA==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@redis/client': ^5.11.0
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -2218,6 +2285,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
 
   cmdk@1.1.1:
     resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
@@ -3741,6 +3812,10 @@ packages:
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redis@5.11.0:
+    resolution: {integrity: sha512-YwXjATVDT+AuxcyfOwZn046aml9jMlQPvU1VXIlLDVAExe0u93aTfPYSeRgG4p9Q/Jlkj+LXJ1XEoFV+j2JKcQ==}
+    engines: {node: '>= 18'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -5424,6 +5499,26 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@redis/bloom@5.11.0(@redis/client@5.11.0)':
+    dependencies:
+      '@redis/client': 5.11.0
+
+  '@redis/client@5.11.0':
+    dependencies:
+      cluster-key-slot: 1.1.2
+
+  '@redis/json@5.11.0(@redis/client@5.11.0)':
+    dependencies:
+      '@redis/client': 5.11.0
+
+  '@redis/search@5.11.0(@redis/client@5.11.0)':
+    dependencies:
+      '@redis/client': 5.11.0
+
+  '@redis/time-series@5.11.0(@redis/client@5.11.0)':
+    dependencies:
+      '@redis/client': 5.11.0
+
   '@rtsao/scc@1.1.0': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -6014,6 +6109,8 @@ snapshots:
   client-only@0.0.1: {}
 
   clsx@2.1.1: {}
+
+  cluster-key-slot@1.1.2: {}
 
   cmdk@1.1.1(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -7691,6 +7788,16 @@ snapshots:
       recharts-scale: 0.4.5
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
+
+  redis@5.11.0:
+    dependencies:
+      '@redis/bloom': 5.11.0(@redis/client@5.11.0)
+      '@redis/client': 5.11.0
+      '@redis/json': 5.11.0(@redis/client@5.11.0)
+      '@redis/search': 5.11.0(@redis/client@5.11.0)
+      '@redis/time-series': 5.11.0(@redis/client@5.11.0)
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
 
   reflect.getprototypeof@1.0.10:
     dependencies:


### PR DESCRIPTION
- Moves validated and broadcast instantly in WS server
- Move events pushed to Redis queue asynchronously  
- Background worker pops queue and persists to PostgreSQL
- Worker retries on DB failure via requeue
- Decouples move latency from database write latency

Horizontal scaling via sticky sessions deferred - 
current single-instance deployment doesn't require it.
Pub/sub implementation tracked for future scaling milestone.