### PR TITLE
feat : add server-authoritive chess clock with live sync to frontend #65

### DIFF
--- a/apps/web/src/app/play/[gameId]/chessBoard.tsx
+++ b/apps/web/src/app/play/[gameId]/chessBoard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { Square } from "chess.js";
-import { GAME_OVER, MOVES } from "../messages";
+import { CLOCK, GAME_OVER, MOVES } from "../messages";
 import { useChessStore } from "@/app/store/chess-game-state";
 import { useSocket } from "@/app/socket-provider";
 import Image from "next/image";
@@ -64,6 +64,7 @@ function ChessBoard() {
     const playerColor = useChessStore((state) => state.color);
     const endGame = useChessStore((state) => state.endGame);
     const applyMove = useChessStore((state) => state.applyMove);
+    const setClock = useChessStore((state) => state.setClock);
     const [from, setFrom] = useState<Square | null>(null);
 
     useEffect(() => {
@@ -77,6 +78,11 @@ function ChessBoard() {
                         const move = message.payload;
                         applyMove({ from: move.from, to: move.to });
                         playSound('move');
+                        break;
+                    }
+                    case CLOCK: {
+                        const { white, black, turn } = message.payload;
+                        setClock({ white, black, turn });
                         break;
                     }
                     case GAME_OVER: {
@@ -101,7 +107,7 @@ function ChessBoard() {
                 }
             }
         }
-    }, [socket, status, playerColor, applyMove, endGame])
+    }, [socket, status, playerColor, applyMove, endGame, setClock])
 
     if (!socket) return <div>Connecting...</div>
     if (!board) return <div>Something went wrong, please try again.</div>

--- a/apps/web/src/app/play/[gameId]/clock.tsx
+++ b/apps/web/src/app/play/[gameId]/clock.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface PlayerClockProps {
+    // Server-authoritative remaining seconds, last synced via a "clock" or
+    // "reconnect" WS message. This component ticks it down locally between
+    // syncs for a smooth countdown, but never invents time on its own.
+    seconds: number
+    isRunning: boolean
+}
+
+export function PlayerClock({ seconds, isRunning }: PlayerClockProps) {
+    const [display, setDisplay] = useState(seconds)
+
+    // Resync to the server's value every time a new one arrives.
+    useEffect(() => {
+        setDisplay(seconds)
+    }, [seconds])
+
+    // Tick locally, only while it's this side's turn.
+    useEffect(() => {
+        if (!isRunning) return
+        const interval = setInterval(() => {
+            setDisplay((prev) => Math.max(prev - 1, 0))
+        }, 1000)
+        return () => clearInterval(interval)
+    }, [isRunning])
+
+    const mins = Math.floor(display / 60)
+    const secs = Math.floor(display % 60)
+    const isLow = display <= 30
+
+    return (
+        <div
+            className={`px-3 py-1 rounded-md font-mono text-sm font-semibold tabular-nums border ${
+                isRunning
+                    ? isLow
+                        ? "bg-red-500/20 text-red-400 border-red-500/40"
+                        : "bg-emerald-500/10 text-emerald-400 border-emerald-500/30"
+                    : "bg-foreground/5 text-muted-foreground border-border"
+            }`}
+        >
+            {mins}:{secs.toString().padStart(2, '0')}
+        </div>
+    )
+}

--- a/apps/web/src/app/play/[gameId]/page.tsx
+++ b/apps/web/src/app/play/[gameId]/page.tsx
@@ -3,6 +3,7 @@
 import ChessBoard from "@/app/play/[gameId]/chessBoard";
 import MovesTable from "@/app/play/[gameId]/movesTable";
 import { AiPanel } from "@/app/play/[gameId]/ai-panel";
+import { PlayerClock } from "@/app/play/[gameId]/clock";
 import { useState, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import {useSocket} from "@/app/socket-provider";
@@ -29,6 +30,7 @@ export default function GamePage() {
         moves,
         gameOver,
         color,
+        clock,
         isAiThinking,
         aiMoveExplanation,
         gameAnalysis,
@@ -71,7 +73,7 @@ export default function GamePage() {
             if (typeof event.data === "string") {
                 const message = JSON.parse(event.data)
                 if (message.type === "reconnect") {
-                    reconnect(message.payload.fen, message.payload.moves ,message.payload.color)
+                    reconnect(message.payload.fen, message.payload.moves, message.payload.color, message.payload.clock)
                 }
             }
         }
@@ -157,9 +159,17 @@ export default function GamePage() {
                                     </p>
                                 </div>
                             </div>
-                            {isAiGame && isAiThinking && (
-                                <span className="text-xs text-violet-400 animate-pulse">Thinking...</span>
-                            )}
+                            <div className="flex items-center gap-3">
+                                {isAiGame && isAiThinking && (
+                                    <span className="text-xs text-violet-400 animate-pulse">Thinking...</span>
+                                )}
+                                {clock && (
+                                    <PlayerClock
+                                        seconds={color === "white" ? clock.black : clock.white}
+                                        isRunning={clock.turn !== color && !gameOver}
+                                    />
+                                )}
+                            </div>
                         </div>
 
                         {/* Chess Board */}
@@ -180,6 +190,12 @@ export default function GamePage() {
                                     </p>
                                 </div>
                             </div>
+                            {clock && (
+                                <PlayerClock
+                                    seconds={color === "white" ? clock.white : clock.black}
+                                    isRunning={clock.turn === color && !gameOver}
+                                />
+                            )}
                         </div>
                     </div>
 

--- a/apps/web/src/app/play/messages.ts
+++ b/apps/web/src/app/play/messages.ts
@@ -1,3 +1,4 @@
 export const INIT_GAME = "init_game";
 export const MOVES = "moves";
 export const GAME_OVER = "game_over"
+export const CLOCK = "clock";

--- a/apps/web/src/app/store/chess-game-state.ts
+++ b/apps/web/src/app/store/chess-game-state.ts
@@ -2,6 +2,14 @@ import {create} from "zustand"
 import {Color, PieceSymbol, Square ,Chess} from "chess.js";
 type Move = {from : string , to : string}
 
+export const DEFAULT_CLOCK_SECONDS = 10 * 60;
+
+type ClockState = {
+    white : number,
+    black : number,
+    turn : "white" | "black",
+}
+
 type ChessState = {
     chess : Chess,
     board : ({
@@ -15,9 +23,12 @@ type ChessState = {
     endGame : (gameOver : boolean) => void,
     applyMove : (move : Move) => void,
     reset : () => void
-    reconnect : (fen : string,moves : Move[],color : string) => void
+    reconnect : (fen : string,moves : Move[],color : string, clock? : ClockState) => void
     color : string,
     gameOver : boolean,
+    // Clock — server-authoritative, only ever set from a "clock"/"reconnect" WS message
+    clock : ClockState | null,
+    setClock : (clock : ClockState) => void,
     // AI game state
     isAiGame : boolean,
     startAiGame : (gameId: string) => void,
@@ -36,6 +47,7 @@ export const useChessStore = create<ChessState>((set,get)=>({
     moves : [],
     color : "white",
     gameOver : false,
+    clock : null,
     // AI game state
     isAiGame : false,
     aiMoveExplanation : null,
@@ -54,6 +66,7 @@ export const useChessStore = create<ChessState>((set,get)=>({
             isAiGame : false,
             aiMoveExplanation : null,
             gameAnalysis : null,
+            clock : { white: DEFAULT_CLOCK_SECONDS, black: DEFAULT_CLOCK_SECONDS, turn: "white" },
         })
     },
 
@@ -70,6 +83,7 @@ export const useChessStore = create<ChessState>((set,get)=>({
             gameAnalysis : null,
             moves : [],
             gameOver : false,
+            clock : null,
         })
     },
 
@@ -88,7 +102,7 @@ export const useChessStore = create<ChessState>((set,get)=>({
         }))
     },
 
-    reconnect : (fen: string, moves, color) => {
+    reconnect : (fen: string, moves, color, clock) => {
         const chess = new Chess();
         chess.load(fen)
         set({
@@ -97,8 +111,11 @@ export const useChessStore = create<ChessState>((set,get)=>({
             board : chess.board(),
             color,
             gameOver : false,
+            clock : clock ?? null,
         })
     },
+
+    setClock : (clock) => set({ clock }),
 
     reset : () => {
         set({
@@ -108,6 +125,7 @@ export const useChessStore = create<ChessState>((set,get)=>({
             aiMoveExplanation : null,
             isAiThinking : false,
             gameAnalysis : null,
+            clock : null,
         })
     },
 

--- a/apps/ws/src/game.ts
+++ b/apps/ws/src/game.ts
@@ -1,6 +1,7 @@
 import {WebSocket} from "ws";
 import {Chess} from "chess.js";
-import {GAME_OVER, INIT_GAME, MOVES} from "./messages";
+import {CLOCK, GAME_OVER, INIT_GAME, MOVES} from "./messages";
+import {Clock, PlayerColor} from "./timer";
 
 interface player {
     playerId : string;
@@ -8,6 +9,7 @@ interface player {
 }
 
 export class Game {
+
     public player1 : player;
     public player2 : player;
     public GAME_ID : string;
@@ -19,8 +21,24 @@ export class Game {
     }[];
     private startTime : Date;
     private moveCount = 0;
+    private clock : Clock;
+    private redis : any;
+    private gameEnded = false;
 
-    constructor(player1 : WebSocket,player2 : WebSocket,GAME_ID : string,player1Id : string, player2Id : string) {
+    TEN_MINUTES = 10 * 60; // 10 minutes in seconds
+
+    // `initialTimes` lets a game reconstructed from the DB (see gameManger.ts
+    // handleDbReconnect) resume with an approximation of the time already
+    // consumed, instead of resetting both clocks to a fresh 10 minutes.
+    constructor(
+        player1 : WebSocket,
+        player2 : WebSocket,
+        GAME_ID : string,
+        player1Id : string,
+        player2Id : string,
+        redis : any,
+        initialTimes? : { white : number, black : number },
+    ) {
         this.player1 = {
             playerId : player1Id,
             Websocket : player1,
@@ -33,6 +51,7 @@ export class Game {
         this.moves = [];
         this.startTime = new Date();
         this.GAME_ID = GAME_ID;
+        this.redis = redis;
 
         if (this.player1 && this.player1.Websocket){
             this.player1.Websocket.send(JSON.stringify({
@@ -53,9 +72,69 @@ export class Game {
             }))
         }
 
+        this.clock = new Clock(
+            (color) => this.handleFlag(color),
+            initialTimes?.white ?? this.TEN_MINUTES,
+            initialTimes?.black ?? this.TEN_MINUTES,
+        );
+        // Not started here: moveCount is only correct for a fresh game (0 = white
+        // to move). For DB-reconstructed games the caller replays moves via
+        // applyMove() after construction, then calls startClockForCurrentTurn().
+    }
+
+    // Starts the clock for whichever color's turn it currently is, based on
+    // moveCount. Call once after construction (fresh game) or once after
+    // replaying past moves (reconnect-from-DB).
+    public startClockForCurrentTurn() {
+        const toMove : PlayerColor = this.moveCount % 2 === 0 ? "white" : "black";
+        this.clock.start(toMove);
+        this.broadcastClock(toMove);
+    }
+
+    // Pushes the authoritative remaining time to both players. Called on setup
+    // and after every processed move so the client never has to compute time on
+    // its own — it just renders whatever the server last sent.
+    private broadcastClock(turn : PlayerColor) {
+        const times = this.clock.snapshot();
+        const payload = JSON.stringify({
+            type : CLOCK,
+            payload : { white : times.white, black : times.black, turn }
+        });
+        this.player1.Websocket?.send(payload);
+        this.player2.Websocket?.send(payload);
+    }
+
+    private async handleFlag(color : PlayerColor) {
+        if (this.gameEnded) return;
+        this.gameEnded = true;
+        this.clock.stop();
+
+        const lostPlayer = color === "white" ? this.player1 : this.player2;
+        const wonPlayer = color === "white" ? this.player2 : this.player1;
+
+        lostPlayer.Websocket?.send(JSON.stringify({
+            type : GAME_OVER,
+            payload : { message : "loss", reason : "timeout" }
+        }));
+        wonPlayer.Websocket?.send(JSON.stringify({
+            type : GAME_OVER,
+            payload : { message : "win", reason : "timeout" }
+        }));
+
+        if (this.redis) {
+            await this.redis.lPush("moves", JSON.stringify({
+                type : "game_over",
+                gameId : this.GAME_ID,
+                reason : "timeout"
+            }));
+        }
     }
 
     public async gameResign(resignPlayerWebsocket : WebSocket ,redis : any){
+        if (this.gameEnded) return;
+        this.gameEnded = true;
+        this.clock.stop();
+
         const resignPlayer = resignPlayerWebsocket;
         const opponentPlayer = resignPlayerWebsocket === this.player1.Websocket ? this.player2 : this.player1;
         resignPlayer.send(JSON.stringify({
@@ -78,9 +157,9 @@ export class Game {
             gameId: this.GAME_ID,
             reason: "resignation"
         }))
-        
+
     }
-    
+
     public async reconnect(socket : WebSocket,userId : string){
         if (this.player1.playerId === userId){
             this.player1.Websocket = socket as WebSocket;
@@ -92,14 +171,14 @@ export class Game {
             payload : {
                 fen : this.board.fen(),
                 moves : this.moves,
-                color : this.player1.playerId === userId ? "white" : "black"
+                color : this.player1.playerId === userId ? "white" : "black",
+                clock : this.clock.snapshot()
             }
         }))
     }
 
     public applyMove(move: { from: string; to: string }) {
         this.board.move(move);
-
         this.moves.push({
             from: move.from,
             to: move.to,
@@ -110,6 +189,12 @@ export class Game {
     }
 
     public async makeMoveById(move : {from : string, to : string}, redis : any, playerId?: string){
+        if (this.gameEnded) return;
+
+        const effectivePlayerId = playerId ?? this.player2.playerId;
+        const moverColor : PlayerColor = effectivePlayerId === this.player1.playerId ? "white" : "black";
+        const nextColor : PlayerColor = moverColor === "white" ? "black" : "white";
+
         try {
             this.applyMove(move);
         } catch (error) {
@@ -119,13 +204,19 @@ export class Game {
         this.player1.Websocket?.send(payload);
         this.player2.Websocket?.send(payload);
 
+        const paused = this.clock.pause();
+        this.clock.start(nextColor);
+        this.broadcastClock(nextColor);
+
         await redis.lPush("moves",JSON.stringify({
             type : "move",
             gameId: this.GAME_ID,
             fen : this.board.fen(),
-            playerId: playerId ?? this.player2.playerId,
+            playerId: effectivePlayerId,
             from: move.from,
             to: move.to,
+            remainingSeconds: paused?.remainingSeconds ?? null,
+            elapsedSeconds: paused?.elapsedSeconds ?? null,
             moveNo: this.moveCount - 1
         }))
     }
@@ -134,11 +225,14 @@ export class Game {
         from : string,
         to : string
     }, userId: string , redis : any) {
+        if (this.gameEnded) return;
         if (this.moveCount % 2 === 0 && socket !== this.player1.Websocket) return;
         if (this.moveCount % 2 === 1 && socket !== this.player2.Websocket) return;
 
         const opponent =
             this.moveCount % 2 === 0 ? this.player2 : this.player1;
+        const moverColor : PlayerColor = this.moveCount % 2 === 0 ? "white" : "black";
+        const nextColor : PlayerColor = moverColor === "white" ? "black" : "white";
 
         try {
             this.applyMove(move);
@@ -151,6 +245,13 @@ export class Game {
             payload: move
         }));
 
+        // pause() always pauses whichever color is currently running — since the
+        // clock is kept in sync with moveCount on every move, that's guaranteed
+        // to be moverColor, so there's no separate color argument to get backwards.
+        const paused = this.clock.pause();
+        this.clock.start(nextColor);
+        this.broadcastClock(nextColor);
+
         await redis.lPush("moves",JSON.stringify({
             type : "move",
             gameId: this.GAME_ID,
@@ -158,12 +259,17 @@ export class Game {
             playerId: userId,
             from: move.from,
             to: move.to,
+            remainingSeconds: paused?.remainingSeconds ?? null,
+            elapsedSeconds: paused?.elapsedSeconds ?? null,
             moveNo: this.moveCount - 1
         }))
 
         if (this.board.isGameOver()) {
 
             if (this.board.isCheckmate()) {
+                this.gameEnded = true;
+                this.clock.stop();
+
                 socket.send(JSON.stringify({
                     type: GAME_OVER,
                     payload: {
@@ -178,6 +284,12 @@ export class Game {
                         message: "loss",
                         reason: "checkmate"
                     }
+                }));
+
+                await redis.lPush("moves", JSON.stringify({
+                    type: "game_over",
+                    gameId: this.GAME_ID,
+                    reason: "checkmate"
                 }));
 
                 return;
@@ -199,6 +311,9 @@ export class Game {
                 }
 
                 if (reason) {
+                    this.gameEnded = true;
+                    this.clock.stop();
+
                     const drawPayload = JSON.stringify({
                         type: GAME_OVER,
                         payload: {
@@ -209,6 +324,12 @@ export class Game {
 
                     socket.send(drawPayload);
                     opponent.Websocket?.send(drawPayload);
+
+                    await redis.lPush("moves", JSON.stringify({
+                        type: "game_over",
+                        gameId: this.GAME_ID,
+                        reason: reason
+                    }));
                 }
             }
         }

--- a/apps/ws/src/gameManger.ts
+++ b/apps/ws/src/gameManger.ts
@@ -52,7 +52,8 @@ export class GameManager {
 
                     });
 
-                    const game = new Game(this.pendingUser.socket, socket, GAME.id, this.pendingUser.userId, userId);
+                    const game = new Game(this.pendingUser.socket, socket, GAME.id, this.pendingUser.userId, userId, this.redis);
+                    game.startClockForCurrentTurn();
                     this.games.push(game);
 
                     this.pendingUser = null;
@@ -146,12 +147,30 @@ export class GameManager {
             // fetch moves, reconstruct board
             const moves = await db.move.findMany({ where: { gameId: gameId }, orderBy: { moveNo: "asc" } });
 
+            // Best-effort reconstruction of remaining clock time from move write
+            // timestamps (the DB doesn't persist per-move duration directly, so
+            // this includes any redis-queue/worker processing lag as "thinking
+            // time" and will therefore run slightly fast — it's an approximation,
+            // not a source of truth for anything but resuming a dropped connection).
+            const TEN_MINUTES = 10 * 60;
+            let whiteRemaining = TEN_MINUTES;
+            let blackRemaining = TEN_MINUTES;
+            let prevTimestamp = gameRecord.createdAt.getTime();
+            for (const m of moves as { moveNo: number; createdAt: Date }[]) {
+                const elapsedSeconds = (m.createdAt.getTime() - prevTimestamp) / 1000;
+                if (m.moveNo % 2 === 0) whiteRemaining = Math.max(whiteRemaining - elapsedSeconds, 0);
+                else blackRemaining = Math.max(blackRemaining - elapsedSeconds, 0);
+                prevTimestamp = m.createdAt.getTime();
+            }
+
             const board = new Game(
                 socket, // reconnecting player
                 null as any, // second player socket may reconnect later
                 gameId,
                 gameRecord.player1Id,
-                gameRecord.player2Id
+                gameRecord.player2Id,
+                this.redis,
+                { white: whiteRemaining, black: blackRemaining }
             );
 
             moves.forEach((m : {
@@ -160,6 +179,7 @@ export class GameManager {
                 playerId : string
             }) => board.applyMove({ from: m.from, to: m.to }));
 
+            board.startClockForCurrentTurn();
             this.games.push(board);
 
             board.reconnect(socket, userId); // send board & moves to reconnecting user

--- a/apps/ws/src/messages.ts
+++ b/apps/ws/src/messages.ts
@@ -1,3 +1,4 @@
 export const INIT_GAME = "init_game";
 export const MOVES = "moves";
 export const GAME_OVER = "game_over"
+export const CLOCK = "clock";

--- a/apps/ws/src/timer.ts
+++ b/apps/ws/src/timer.ts
@@ -1,0 +1,75 @@
+export type PlayerColor = "white" | "black";
+
+export class Clock {
+    private whiteTime: number; // seconds remaining
+    private blackTime: number; // seconds remaining
+    private running: PlayerColor | null = null;
+    private timerHandle: NodeJS.Timeout | null = null;
+    private lastStart = 0;
+    private readonly onFlag: (color: PlayerColor) => void;
+
+    constructor(
+        onFlag: (color: PlayerColor) => void,
+        whiteTime: number,
+        blackTime: number = whiteTime,
+    ) {
+        this.whiteTime = whiteTime;
+        this.blackTime = blackTime;
+        this.onFlag = onFlag;
+    }
+
+    public start(color: PlayerColor) {
+        this.stop();
+        this.running = color;
+        this.lastStart = Date.now();
+        const remaining = color === "white" ? this.whiteTime : this.blackTime;
+        this.timerHandle = setTimeout(() => {
+            this.timerHandle = null;
+            this.running = null;
+            this.onFlag(color);
+        }, Math.max(remaining, 0) * 1000);
+    }
+
+    // Pauses whichever color is currently running (the mover, by construction) and
+    // returns its remaining time + how long that turn took. Returns null if nothing
+    // was running (e.g. called after the clock was already stopped).
+    public pause(): { color: PlayerColor; remainingSeconds: number; elapsedSeconds: number } | null {
+        if (!this.running || !this.timerHandle) return null;
+        clearTimeout(this.timerHandle);
+        this.timerHandle = null;
+
+        const color = this.running;
+        const elapsedSeconds = (Date.now() - this.lastStart) / 1000;
+        const remainingSeconds = Math.max(
+            (color === "white" ? this.whiteTime : this.blackTime) - elapsedSeconds,
+            0,
+        );
+
+        if (color === "white") this.whiteTime = remainingSeconds;
+        else this.blackTime = remainingSeconds;
+        this.running = null;
+
+        return { color, remainingSeconds, elapsedSeconds };
+    }
+
+    public stop() {
+        if (this.timerHandle) {
+            clearTimeout(this.timerHandle);
+            this.timerHandle = null;
+        }
+        this.running = null;
+    }
+
+    // Remaining time for both sides right now, accounting for whichever is
+    // currently running, without mutating stored state. Safe to call anytime.
+    public snapshot(): { white: number; black: number } {
+        let white = this.whiteTime;
+        let black = this.blackTime;
+        if (this.running && this.timerHandle) {
+            const elapsed = (Date.now() - this.lastStart) / 1000;
+            if (this.running === "white") white = Math.max(white - elapsed, 0);
+            else black = Math.max(black - elapsed, 0);
+        }
+        return { white, black };
+    }
+}


### PR DESCRIPTION
## Summary

Adds a real, server-authoritative chess clock. Previously there was no clock at all — `Game` set an unused `startTime: Date` once and never touched it again. This PR gives each game a 10-minute-per-side clock that the **server** owns and validates, with live updates pushed to both clients so the UI can render a countdown that stays in sync.

## What changed

### Backend (`apps/ws`)
- **`timer.ts` (new)** — a `Clock` class that tracks `whiteTime`/`blackTime` in seconds. `pause()` always pauses whichever side is currently running (no color argument to get backwards), `start(color)` starts a specific side, and `snapshot()` gives a non-mutating read of current remaining time for both sides. Flags via an `onFlag` callback rather than messaging sockets directly, keeping `Clock` decoupled from `Game`.
- **`game.ts`**
  - `makeMove` and `makeMoveById` now correctly `pause()` the mover's clock and `start()` the next player's on every move (agent-driven moves via `makeMoveById` previously skipped the clock entirely).
  - Added `handleFlag()` — when a side's time runs out, both players get a `GAME_OVER` message (`reason: "timeout"`), reusing the existing win/loss contract instead of inventing a new message shape.
  - Added a `gameEnded` guard + `clock.stop()` at every game-ending path (timeout, resignation, checkmate, draw) so no stale timer can fire after a game is already over.
  - Checkmate/draw endings now also push a `game_over` event to Redis (previously only resignation did this, so the worker never marked those games `FINISHED` in the DB).
  - `reconnect()` now includes a live clock snapshot in its payload.
  - Added `broadcastClock()`, which pushes `{white, black, turn}` to both sockets on clock start and after every move, so clients never have to compute time themselves.
- **`gameManger.ts`** — both `new Game(...)` call sites now pass `redis` and call `startClockForCurrentTurn()`. The DB-reconstruction reconnect path (used when a game isn't in memory, e.g. after a server restart) now approximates each side's remaining time from move `createdAt` timestamps instead of resetting both clocks to a fresh 10 minutes.
- **`messages.ts`** — added `CLOCK` message type.

### Frontend (`apps/web`)
- **`clock.tsx` (new)** — `PlayerClock` component: renders `mm:ss`, ticks down locally once per second only while `isRunning`, and resyncs to the server's authoritative value on every `clock`/`reconnect` message so drift never accumulates.
- **`chess-game-state.ts`** — added `clock: {white, black, turn} | null` to the Zustand store, a `setClock` action, and extended `reconnect(...)` to carry the clock snapshot. AI games get `clock: null` since there's no backend `Game`/`Clock` instance behind them.
- **`chessBoard.tsx`** — handles the new `CLOCK` message type in the existing socket switch.
- **`page.tsx`** — renders a `PlayerClock` next to the opponent's info block and one next to the player's own, each bound to the correct color and running state.

## Testing

- `apps/ws` and `apps/web` both typecheck clean (`tsc --noEmit`).
- Manually played through a live game in the browser — moves sync over the websocket, both clocks count down and swap sides correctly on each move, and the game-over dialog renders correctly.

## Known limitations / follow-ups

- Remaining time reconstructed on DB-based reconnect (server restart mid-game) is a best-effort approximation from move write timestamps — it counts Redis-queue/worker processing lag as thinking time, so it runs slightly fast. An exact fix would need a schema change to persist per-move elapsed time.
- AI games have no clock — the AI-move path doesn't go through the `Game`/`Clock` instance at all, so there's nothing authoritative to show. Clock UI is hidden for AI games rather than showing a meaningless countdown.